### PR TITLE
Add merchant-referring-name fields to an order

### DIFF
--- a/gateway/builders/merchant_order_builder.py
+++ b/gateway/builders/merchant_order_builder.py
@@ -155,3 +155,19 @@ class MerchantOrderBuilder(object):
                 self.__req_params.GENERAL_DATA_ORDER_DATA_RECIPIENT_NAME: recipient_name
             }
         )
+
+    def add_merchant_referring_name(self, name=None):
+        """
+        Add merchant referring name for dynamic descriptor
+
+        Args:
+            name (str): merchant referring name
+        """
+        self.__data_structure_util.add_to_dict(
+            source_dict=self.__general_data_set[self.__GENERAL_DATA_KEY],
+            working_dict=self.__order_data_structure,
+            new_key=self.__ORDER_DATA_KEY,
+            new_dict={
+                self.__req_params.GENERAL_DATA_ORDER_DATA_MERCHANT_REFERRING_NAME: name
+            }
+        )

--- a/gateway/data_sets/request_parameters.py
+++ b/gateway/data_sets/request_parameters.py
@@ -64,6 +64,7 @@ class RequestParameters:
     GENERAL_DATA_ORDER_DATA_ORDER_META = 'order-meta'
     GENERAL_DATA_ORDER_DATA_MERCHANT_SIDE_URL = 'merchant-side-url'
     GENERAL_DATA_ORDER_DATA_RECIPIENT_NAME = 'recipient-name'
+    GENERAL_DATA_ORDER_DATA_MERCHANT_REFERRING_NAME = 'merchant-referring-name'
 
     # Payment data sets
     PAYMENT_METHOD_DATA_PAN = 'pan'
@@ -126,6 +127,7 @@ class RequestParametersTypes(RequestParameters):
     GENERAL_DATA_ORDER_DATA_ORDER_META = str
     GENERAL_DATA_ORDER_DATA_MERCHANT_SIDE_URL = str
     GENERAL_DATA_ORDER_DATA_RECIPIENT_NAME = str
+    GENERAL_DATA_ORDER_DATA_MERCHANT_REFERRING_NAME = str
 
     # Payment data sets
     PAYMENT_METHOD_DATA_PAN = str

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+pypandoc
 requests

--- a/tests/builders/test_merchant_order_builder.py
+++ b/tests/builders/test_merchant_order_builder.py
@@ -96,6 +96,13 @@ class TestMerchantOrderBuilder(TestCase):
             new.add_recipient_name('Lorem Ipsum is simply dummy text of the printing and typesetting industry.')
         mock.assert_called_once_with('Lorem Ipsum is simply dummy text of the printing and typesetting industry.')
 
+    def test_build_with_add_merchant_referring_name(self):
+        """Will succeed"""
+        new = self.BUILDER
+        with patch.object(new, 'add_merchant_referring_name') as mock:
+            new.add_merchant_referring_name('Lorem Ipsum')
+        mock.assert_called_once_with('Lorem Ipsum')
+
     def test_merchant_data_structure_build(self):
         valid_data_structure = {
             'general-data': {
@@ -103,6 +110,9 @@ class TestMerchantOrderBuilder(TestCase):
                     'order-id': 'UnitTestIdOforder_id',
                     'merchant-transaction-id': 'UnitTestIdOftransaction_id',
                     'order-description': 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.',
+                    'merchant-side-url': 'http://side.url',
+                    'recipient-name': 'Jone Doe',
+                    'merchant-referring-name': 'REF NAME',
                     'order-meta': {
                         'url': 'nice.example.com',
                         'sequence': '0',
@@ -115,15 +125,12 @@ class TestMerchantOrderBuilder(TestCase):
         }
 
         new = self.BUILDER
-        new.add_merchant_transaction_id(
-            transaction_id='UnitTestIdOftransaction_id'
-        )
-        new.add_merchant_order_id(
-            order_id='UnitTestIdOforder_id'
-        )
-        new.add_merchant_order_description(
-            description='Lorem Ipsum is simply dummy text of the printing and typesetting industry.'
-        )
+        new.add_merchant_transaction_id('UnitTestIdOftransaction_id')
+        new.add_merchant_order_id('UnitTestIdOforder_id')
+        new.add_merchant_order_description('Lorem Ipsum is simply dummy text of the printing and typesetting industry.')
+        new.add_merchant_side_url('http://side.url')
+        new.add_recipient_name('Jone Doe')
+        new.add_merchant_referring_name('REF NAME')
         new.add_merchant_order_meta(
             json_object={
                 'f_name': 'Jane',


### PR DESCRIPTION
Add merchant-referring-name fields to an order. Is required for dynamic descriptor.