### PR TITLE
Added new fields for order data to satisfy AN5524 requirements:

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v1

--- a/gateway/builders/merchant_order_builder.py
+++ b/gateway/builders/merchant_order_builder.py
@@ -235,3 +235,37 @@ class MerchantOrderBuilder(object):
                 self.__req_params.GENERAL_DATA_ORDER_DATA_RECURRING_FREQUENCY: recurring_frequency
             }
         )
+
+    def set_mits_expected(self, mits_expected=True):
+        """
+        Set flag that subsequent MIT transactions are supposed to be
+
+        Args:
+            mits_expected (bool): must be set to true for UCOF initialization if any subsequent MIT transactions
+            are supposed to be
+        """
+        self.__data_structure_util.add_to_dict(
+            source_dict=self.__general_data_set[self.__GENERAL_DATA_KEY],
+            working_dict=self.__order_data_structure,
+            new_key=self.__ORDER_DATA_KEY,
+            new_dict={
+                self.__req_params.GENERAL_DATA_ORDER_DATA_MITS_EXPECTED: mits_expected
+            }
+        )
+
+    def set_variable_amount_recurring(self, variable_amount_recurring=True):
+        """
+        Set flag that amount will not be fixed for subsequent transactions
+
+        Args:
+            variable_amount_recurring (bool): must be set to true for initial recurring transaction
+            if amount will not be fixed for subsequent transactions
+        """
+        self.__data_structure_util.add_to_dict(
+            source_dict=self.__general_data_set[self.__GENERAL_DATA_KEY],
+            working_dict=self.__order_data_structure,
+            new_key=self.__ORDER_DATA_KEY,
+            new_dict={
+                self.__req_params.GENERAL_DATA_ORDER_DATA_VARIABLE_AMOUNT_RECURRING: variable_amount_recurring
+            }
+        )

--- a/gateway/data_sets/request_parameters.py
+++ b/gateway/data_sets/request_parameters.py
@@ -73,6 +73,8 @@ class RequestParameters:
     GENERAL_DATA_ORDER_DATA_CUSTOM_RETURN_URL = 'custom-return-url'
     GENERAL_DATA_ORDER_DATA_RECURRING_EXPIRY = 'recurring-expiry'
     GENERAL_DATA_ORDER_DATA_RECURRING_FREQUENCY = 'recurring-frequency'
+    GENERAL_DATA_ORDER_DATA_MITS_EXPECTED = 'mits-expected'
+    GENERAL_DATA_ORDER_DATA_VARIABLE_AMOUNT_RECURRING = 'variable-amount-recurring'
 
     # Payment data sets
     PAYMENT_METHOD_DATA_PAN = 'pan'
@@ -164,6 +166,8 @@ class RequestParametersTypes(RequestParameters):
     GENERAL_DATA_ORDER_DATA_CUSTOM_RETURN_URL = str
     GENERAL_DATA_ORDER_DATA_RECURRING_EXPIRY = str
     GENERAL_DATA_ORDER_DATA_RECURRING_FREQUENCY = str
+    GENERAL_DATA_ORDER_DATA_MITS_EXPECTED = bool
+    GENERAL_DATA_ORDER_DATA_VARIABLE_AMOUNT_RECURRING = bool
 
     # Payment data sets
     PAYMENT_METHOD_DATA_PAN = str

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ required = [
 
 setuptools.setup(
     name='transactpro-gw3-client',
-    version='1.7.7',
+    version='1.7.8',
     description='Transact PRO Gateway3 implementation in Python.',
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",

--- a/tests/builders/test_merchant_order_builder.py
+++ b/tests/builders/test_merchant_order_builder.py
@@ -50,6 +50,8 @@ class TestMerchantOrderBuilder(TestCase):
                     'custom-return-url': 'https://another-example.com',
                     'recurring-expiry': '20310131',
                     'recurring-frequency': '30',
+                    'mits-expected': True,
+                    'variable-amount-recurring': True,
                     'order-meta': {
                         'url': 'nice.example.com',
                         'sequence': '0',
@@ -72,6 +74,8 @@ class TestMerchantOrderBuilder(TestCase):
         new.add_custom_return_url('https://another-example.com')
         new.add_recurring_expiry('20310131')
         new.add_recurring_frequency('30')
+        new.set_mits_expected()
+        new.set_variable_amount_recurring()
         new.add_merchant_order_meta(
             json_object={
                 'f_name': 'Jane',


### PR DESCRIPTION
 - mits-expected: must be set to true for UCOF initialization if any subsequent MIT transactions are supposed to be
 - variable-amount-recurring: must be set to true for initial recurring transaction if amount will not be fixed for subsequent transactions